### PR TITLE
Clean up calibration code

### DIFF
--- a/main.py
+++ b/main.py
@@ -154,7 +154,6 @@ def mainloop():
             len(scores) * [None],  # don't feed landmarks
             # TODO: revisit this when we have improved homography-based transform
             temps,
-            CALIBRATE,
             CALIB_BOX,
             IR_WIN_SIZE,
             CMAP_TEMP_MIN,
@@ -223,6 +222,9 @@ if __name__ == "__main__":
 
     ir_thread = IRThread()
     ir_thread.start()
+
+    if not CALIBRATE:
+        CALIB_BOX = None
 
     if SAVE_FRAMES:
         executor = ThreadPoolExecutor(max_workers=4)

--- a/ui/interface.py
+++ b/ui/interface.py
@@ -70,7 +70,7 @@ def draw_box(arr, box):
 
 
 def make_ir_view(
-    arr, scores, boxes, landms, temps, calibrate, calib_box, win_size, thr_min=32, thr_max=40
+    arr, scores, boxes, landms, temps, calib_box, win_size, thr_min=32, thr_max=40
 ):
 
     W, H = win_size
@@ -78,8 +78,9 @@ def make_ir_view(
     arr = colormap(arr, thr_min, thr_max)
 
     # draw the calib box if calibration is specified
-    if calibrate: 
+    if calib_box is not None:
         draw_box(arr, calib_box)
+
 
     for score, box, landm, temp in zip(scores, boxes, landms, temps):
 

--- a/ui/interface.py
+++ b/ui/interface.py
@@ -70,14 +70,16 @@ def draw_box(arr, box):
 
 
 def make_ir_view(
-    arr, scores, boxes, landms, temps, calib_box, win_size, thr_min=32, thr_max=40
+    arr, scores, boxes, landms, temps, calibrate, calib_box, win_size, thr_min=32, thr_max=40
 ):
 
     W, H = win_size
     arr = cv2.resize(arr, (W, H))
     arr = colormap(arr, thr_min, thr_max)
 
-    draw_box(arr, calib_box)
+    # draw the calib box if calibration is specified
+    if calibrate: 
+        draw_box(arr, calib_box)
 
     for score, box, landm, temp in zip(scores, boxes, landms, temps):
 


### PR DESCRIPTION
-Create function that wraps calibration logic in main.py
-Disable calib box in interface.py if calibration is disabled as calibration box can confuse users

Tested on jetson nano and xavier NX